### PR TITLE
PR: Member 등록 구현

### DIFF
--- a/coffee/build.gradle
+++ b/coffee/build.gradle
@@ -25,6 +25,8 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	implementation 'mysql:mysql-connector-java:8.0.32'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+	testImplementation 'org.springframework.security:spring-security-test'
 }
 
 tasks.named('test') {

--- a/coffee/src/main/java/com/cnu/coffee/configuration/SecurityConfig.java
+++ b/coffee/src/main/java/com/cnu/coffee/configuration/SecurityConfig.java
@@ -54,7 +54,6 @@ public class SecurityConfig {
                     .accessDeniedHandler(accessDeniedHandler())
                     .and()
                 .csrf().disable()
-
         ;
     return http.build();
     }

--- a/coffee/src/main/java/com/cnu/coffee/configuration/SecurityConfig.java
+++ b/coffee/src/main/java/com/cnu/coffee/configuration/SecurityConfig.java
@@ -1,0 +1,61 @@
+package com.cnu.coffee.configuration;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.access.AccessDeniedHandler;
+
+import javax.servlet.http.HttpServletResponse;
+
+@Slf4j
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+    private final ApplicationContext applicationContext;
+
+    @Bean
+    PasswordEncoder passwordEncoder(){return new BCryptPasswordEncoder();}
+
+    AccessDeniedHandler accessDeniedHandler(){
+        return (request, response, e) ->{
+            Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+            Object principal = authentication != null ? authentication.getPrincipal() : null;
+            log.warn("{} id denied", principal, e);
+            response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+            response.setContentType("text/plain;charset=UTF-8");
+            response.getWriter().write("ACCESS DENIED");
+            response.getWriter().flush();
+            response.getWriter().close();
+        };
+    }
+
+    @Bean
+    SecurityFilterChain filterChain(HttpSecurity http) throws Exception{
+        http.authorizeRequests()
+                .antMatchers(HttpMethod.POST, "/member").permitAll()
+                .antMatchers(HttpMethod.GET, "/member/**").hasAnyRole("USER","ADMIN")
+                .antMatchers(HttpMethod.PUT, "/member").hasAnyRole("USER","ADMIN")
+                .antMatchers(HttpMethod.DELETE, "/member").hasAnyRole("USER","ADMIN")
+                .anyRequest().permitAll()
+                    .and()
+                .exceptionHandling()
+                    .accessDeniedHandler(accessDeniedHandler())
+                    .and()
+                .csrf().disable()
+
+        ;
+    return http.build();
+    }
+}

--- a/coffee/src/main/java/com/cnu/coffee/member/Member.java
+++ b/coffee/src/main/java/com/cnu/coffee/member/Member.java
@@ -1,0 +1,43 @@
+package com.cnu.coffee.member;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.GenericGenerator;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Builder
+@Getter
+@Entity
+@Table(name = "members")
+@AllArgsConstructor
+@NoArgsConstructor
+public class Member {
+    @Id
+    @GeneratedValue(generator = "uuid2")
+    @GenericGenerator(name = "uuid2", strategy = "uuid2")
+    @Column(name = "id", nullable = false, unique = true, columnDefinition = "BINARY(16)")
+    private UUID id;
+
+    @Column(name = "nick_name", nullable = false, length = 10)
+    private String nickName;
+
+    @Column(name = "email", nullable = false, unique = true, length = 50)
+    private String email;
+
+    @Column(name = "ebcrypted_pswd", nullable = false)
+    private String credential;
+
+    @Enumerated(EnumType.ORDINAL)
+    @Column(name = "role")
+    private Role role;
+
+    @Column(name = "registered_date", nullable = false, columnDefinition = "TIMESTAMP")
+    private LocalDateTime registeredDate;
+
+    private LocalDateTime modifiedDate;
+}

--- a/coffee/src/main/java/com/cnu/coffee/member/MemberController.java
+++ b/coffee/src/main/java/com/cnu/coffee/member/MemberController.java
@@ -1,0 +1,20 @@
+package com.cnu.coffee.member;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/member")
+public class MemberController {
+
+    @Autowired
+    private MemberService memberService;
+
+    @PostMapping("")
+    public MemberResponseDto registerMember(@RequestBody MemberReuqestDto memberReuqestDto){
+        return memberService.register(memberReuqestDto);
+    }
+}

--- a/coffee/src/main/java/com/cnu/coffee/member/MemberRepository.java
+++ b/coffee/src/main/java/com/cnu/coffee/member/MemberRepository.java
@@ -1,0 +1,10 @@
+package com.cnu.coffee.member;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.UUID;
+
+@Repository
+public interface MemberRepository extends JpaRepository<Member, UUID> {
+}

--- a/coffee/src/main/java/com/cnu/coffee/member/MemberResponseDto.java
+++ b/coffee/src/main/java/com/cnu/coffee/member/MemberResponseDto.java
@@ -1,0 +1,14 @@
+package com.cnu.coffee.member;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.UUID;
+
+@Getter
+@Setter
+public class MemberResponseDto {
+    private UUID id;
+    private String nickName;
+    private String email;
+}

--- a/coffee/src/main/java/com/cnu/coffee/member/MemberReuqestDto.java
+++ b/coffee/src/main/java/com/cnu/coffee/member/MemberReuqestDto.java
@@ -1,0 +1,21 @@
+package com.cnu.coffee.member;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.UUID;
+
+@Getter
+@Setter
+public class MemberReuqestDto {
+
+    private String nickName;
+
+    private String email;
+
+    private String credential;
+
+    private Role role;
+
+}

--- a/coffee/src/main/java/com/cnu/coffee/member/MemberService.java
+++ b/coffee/src/main/java/com/cnu/coffee/member/MemberService.java
@@ -1,0 +1,36 @@
+package com.cnu.coffee.member;
+
+import org.springframework.beans.BeanUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+
+@Service
+public class MemberService {
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    public MemberResponseDto convertEntityToDto(Member entity){
+        MemberResponseDto dto = new MemberResponseDto();
+        BeanUtils.copyProperties(entity, dto);
+        return dto;
+    }
+
+    public MemberResponseDto register(MemberReuqestDto memberReuqestDto) {
+        Member member = Member.builder()
+                .email(memberReuqestDto.getEmail())
+                .nickName(memberReuqestDto.getNickName())
+                .role(memberReuqestDto.getRole())
+                .credential(passwordEncoder.encode(memberReuqestDto.getCredential()))
+                .registeredDate(LocalDateTime.now())
+                .modifiedDate(LocalDateTime.now())
+                .build();
+        Member saved = memberRepository.save(member);
+        return convertEntityToDto(saved);
+    }
+}

--- a/coffee/src/main/java/com/cnu/coffee/member/Role.java
+++ b/coffee/src/main/java/com/cnu/coffee/member/Role.java
@@ -1,0 +1,5 @@
+package com.cnu.coffee.member;
+
+public enum Role {
+    USER, ADMIN
+}

--- a/coffee/src/main/java/com/cnu/coffee/order/OrderController.java
+++ b/coffee/src/main/java/com/cnu/coffee/order/OrderController.java
@@ -9,7 +9,7 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
 @RestController
-@RequestMapping("api/v1/order")
+@RequestMapping("/order")
 public class OrderController {
 
     @Autowired

--- a/coffee/src/main/java/com/cnu/coffee/product/ProductController.java
+++ b/coffee/src/main/java/com/cnu/coffee/product/ProductController.java
@@ -10,7 +10,7 @@ import java.util.List;
 import java.util.UUID;
 
 @RestController
-@RequestMapping("api/v1/product")
+@RequestMapping("/product")
 public class ProductController {
 
     @Autowired

--- a/coffee/src/main/resources/application-test.yml
+++ b/coffee/src/main/resources/application-test.yml
@@ -23,3 +23,7 @@ logging:
   level:
     org.hibernate.type.descriptor.sql: debug
     org.hibernate.SQL: debug
+
+server:
+  servlet:
+    context-path: /api/v1

--- a/coffee/src/main/resources/application.yml
+++ b/coffee/src/main/resources/application.yml
@@ -23,3 +23,7 @@ logging:
   level:
     org.hibernate.type.descriptor.sql: debug
     org.hibernate.SQL: debug
+
+server:
+  servlet:
+    context-path: /api/v1

--- a/coffee/src/test/java/com/cnu/coffee/member/MemberControllerTest.java
+++ b/coffee/src/test/java/com/cnu/coffee/member/MemberControllerTest.java
@@ -1,0 +1,57 @@
+package com.cnu.coffee.member;
+
+import com.cnu.coffee.product.domain.ProductResponseDto;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class MemberControllerTest {
+
+    private static final Logger logger = LoggerFactory.getLogger(MemberControllerTest.class);
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    @DisplayName("유저 등록")
+    void testRegister() throws Exception {
+        MemberReuqestDto requestDto = new MemberReuqestDto();
+        requestDto.setNickName("심심한 바다코끼리");
+        requestDto.setEmail("sample@abc.com");
+        requestDto.setRole(Role.USER);
+        requestDto.setCredential("test1234@#");
+
+        MvcResult result = mockMvc.perform(post("/member")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(requestDto)))
+                .andExpect(status().isOk())
+                .andDo(print())
+                .andReturn();
+
+        String content = result.getResponse().getContentAsString();
+        MemberResponseDto responseDto = objectMapper.readValue(content, MemberResponseDto.class);
+        logger.info("inserted product -> {}", responseDto);
+    }
+
+}

--- a/coffee/src/test/java/com/cnu/coffee/product/ProductControllerTest.java
+++ b/coffee/src/test/java/com/cnu/coffee/product/ProductControllerTest.java
@@ -78,7 +78,7 @@ class ProductControllerTest {
                 .build();
 
 
-        MvcResult result = mockMvc.perform(post("/api/v1/product")
+        MvcResult result = mockMvc.perform(post("/product")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(productRequestDTO)))
                 .andExpect(status().isOk())
@@ -93,7 +93,7 @@ class ProductControllerTest {
     @Test
     @DisplayName("상품 조회: 단건조회")
     void testFind() throws Exception {
-        mockMvc.perform(get("/api/v1/product/{id}", product.getId().toString()))
+        mockMvc.perform(get("/product/{id}", product.getId().toString()))
                 .andExpect(status().isOk())
                 .andDo(print());
 
@@ -112,7 +112,7 @@ class ProductControllerTest {
         productService.insertProduct(productRequestDTO);
 
 
-        mockMvc.perform(get("/api/v1/product/all"))
+        mockMvc.perform(get("/product/all"))
                 .andExpect(status().isOk())
                 .andDo(print());
     }
@@ -127,7 +127,7 @@ class ProductControllerTest {
                 .description(Optional.of("맛있는 커피 😊"))
                 .build();
 
-        MvcResult result = mockMvc.perform(put("/api/v1/product/{id}", product.getId().toString())
+        MvcResult result = mockMvc.perform(put("/product/{id}", product.getId().toString())
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(productRequestDto)))
                 .andExpect(status().isOk())
@@ -153,7 +153,7 @@ class ProductControllerTest {
 
         ProductResponseDto productResponseDto = productService.insertProduct(productRequestDto);
 
-        mockMvc.perform(delete("/api/v1/product/{id}", productResponseDto.getId().toString()))
+        mockMvc.perform(delete("/product/{id}", productResponseDto.getId().toString()))
                 .andExpect(status().isOk())
                 .andDo(print());
     }
@@ -171,7 +171,7 @@ class ProductControllerTest {
 
         logger.info("before delete all -> {}", productService.findAllProducts());
 
-        mockMvc.perform(delete("/api/v1/product/deleteAll"))
+        mockMvc.perform(delete("/product/deleteAll"))
                 .andExpect(status().isOk())
                 .andDo(print());
 


### PR DESCRIPTION
### 구현 내용
Member 등록까지 구현했습니다!
- **Member**: 회원 정보를 담는 entity
    - Role(Enum): Member의 권한 정보
- **MemberController, Service, Repository**: Member와 관련된 비즈니스 로직 수행
- **MemberResponseDto, MemberRequestDto**: Member 등록과 관련된 요청/응답 객체

### 중점적으로 봐주셨으면 하는 부분
- Member를 등록하고 결과를 반환할 때, 식별자(id)값이 필요할까요? 사실, **멤버 등록의 결과물로 멤버에 대한 정보가 필요할지 잘 모르겠습니다.** 아래와 같이 **환영메세지**를 보여주고, 로그인 절차를 한 번 더 거치게 되니까, 등록된 email에 대한 정보 말고 딱히 필요한게 없을 것 같은데, 아무것도 주지 않자니 약간 허전(..)합니다
> ${email}님, 등록을 환영합니다
- JWT를 활용하여 로그인 기능을 구현하려고 하는데, 
    - **JWT 로그아웃**을,,,,, 어떻게 구현해야 할지 감이 잘 오지 않습니다😂 (프로그래머스 강의에 없어서 더더욱이요 ㅜㅜ)
    - 현업에서는 **Session과 JWT** 중, 어느 것을 사용하는 추세인가요?

### 앞으로 구현할 내용
- JWT 로그인
- Member 조회/수정/삭제

_p.s_
_브랜치를 새로 딴다는게,, 깜빡하고 그대로 push 해버려서..😰.. 
새로운 브랜치는 다음 commit에 jwt라는 이름으로 따겠습니다😭_